### PR TITLE
Canary release

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Requirements mentioned above are based on these modules which are used in this r
     - name: canary_release_count
       description: No of instance to be updated automatically with new AMI for canary release (Should be strictly less than ASG size) .
       value: 0
-    - name: replace_instances
+    - name: canary_release_instance_ids
       description: Instance ids to be updated manually with new AMI for canary release (Should be strictly less than ASG size) .
       value: []
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Requirements mentioned above are based on these modules which are used in this r
 
       canary_release_count: 0
 
-      replace_instances: []
+      canary_release_instance_ids: []
 
       # Set this to false if you have done canary release
       # for AMI version for optimal instance cost.
@@ -163,16 +163,16 @@ Requirements mentioned above are based on these modules which are used in this r
 
       # Canary release count should be less than ASG
       # instance size, otherwise deployment will fail.
-      # If canary_release_count > 0 then replace_instances should not be used.
+      # If canary_release_count > 0 then canary_release_instance_ids should not be used.
       # Both variables cannot be used at same time
       canary_release_count: 3
 
       # Set this to instance ids to be replaced in canary release.
       # No of instances should be strictly less than instance count in ASG.
       # Incorrect instance ids will result in failed deployment.
-      # If replace_instances size > 0, canary_release_count should not be used.
+      # If canary_release_instance_ids size > 0, canary_release_count should not be used.
       # Both variables cannot be used at same time
-      replace_instances: ["i-97593jjeief8488", "i-97593juoo98"]
+      canary_release_instance_ids: ["i-97593jjeief8488", "i-97593juoo98"]
 
       replace_new_instances: true
 

--- a/README.md
+++ b/README.md
@@ -45,8 +45,11 @@ Requirements mentioned above are based on these modules which are used in this r
       description: Suffix that will be added to Launch Configurations which are going to be created and deleted by this role.
       value: rolling
     - name: canary_release_count
-      description: No of instance to be updated with new AMI for canary release (Should be less than ASG size) .
+      description: No of instance to be updated automatically with new AMI for canary release (Should be strictly less than ASG size) .
       value: 0
+    - name: replace_instances
+      description: Instance ids to be updated manually with new AMI for canary release (Should be strictly less than ASG size) .
+      value: []
 
 ### Required Variables ###
 
@@ -95,7 +98,7 @@ Requirements mentioned above are based on these modules which are used in this r
   connection: local
   vars:
     # set common_java_opts in supervisor using the ami baking playbook!
-    app_memory_java_opts: >- 
+    app_memory_java_opts: >-
       -Xms1g -Xmx1g -XX:PermSize=512m -XX:MaxPermSize=512m
     instance_count: 1
   roles:
@@ -114,6 +117,8 @@ Requirements mentioned above are based on these modules which are used in this r
       asg_desired_capacity: "{{ instance_count }}"
 
       canary_release_count: 0
+
+      replace_instances: []
 
       # Set this to false if you have done canary release
       # for AMI version for optimal instance cost.
@@ -158,7 +163,16 @@ Requirements mentioned above are based on these modules which are used in this r
 
       # Canary release count should be less than ASG
       # instance size, otherwise deployment will fail.
+      # If canary_release_count > 0 then replace_instances should not be used.
+      # Both variables cannot be used at same time
       canary_release_count: 3
+
+      # Set this to instance ids to be replaced in canary release.
+      # No of instances should be strictly less than instance count in ASG.
+      # Incorrect instance ids will result in failed deployment.
+      # If replace_instances size > 0, canary_release_count should not be used.
+      # Both variables cannot be used at same time
+      replace_instances: ["i-97593jjeief8488", "i-97593juoo98"]
 
       replace_new_instances: true
 

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Requirements mentioned above are based on these modules which are used in this r
       # instance size, otherwise deployment will fail.
       canary_release_count: 3
 
-      replace_new_instances: false
+      replace_new_instances: true
 
       instance_user_data: |
         #cloud-config

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,3 +9,4 @@ ebs_delete_on_termination: true
 launch_configuration_name_suffix: rolling
 replace_new_instances: true
 canary_release_count: 0
+replace_instances: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,4 +9,4 @@ ebs_delete_on_termination: true
 launch_configuration_name_suffix: rolling
 replace_new_instances: true
 canary_release_count: 0
-replace_instances: []
+canary_release_instance_ids: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,3 +8,4 @@ ebs_volume_type: gp2
 ebs_delete_on_termination: true
 launch_configuration_name_suffix: rolling
 replace_new_instances: true
+canary_release_count: 0

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -148,7 +148,7 @@
     wait_for_instances: "{{ asg_wait_for_instances }}"
     wait_timeout: "{{ asg_wait_timeout }}"
   when:
-      - canary_release_count <= 0
+    - canary_release_count <= 0
 
 - name: Delete the Old Launch Configuration
   ec2_lc:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,16 +6,16 @@
 
 - name: Check if invalid canary release
   fail:
-    msg: "Got `replace_instances` and `canary_release_count` both set. Please use only 1 parameter at a time for canary release."
+    msg: "Got `canary_release_instance_ids` and `canary_release_count` both set. Please use only 1 parameter at a time for canary release."
   when:
-    - replace_instances|length > 0
+    - canary_release_instance_ids|length > 0
     - canary_release_count > 0
 
 - name: Set replace_new_instance to true for canary release
   set_fact:
     replace_new_instance: true
   when:
-    - replace_instances|length > 0 or canary_release_count > 0
+    - canary_release_instance_ids|length > 0 or canary_release_count > 0
 
 - name: Get the AMI
   ec2_ami_facts:
@@ -104,10 +104,10 @@
 
 - name: Fail If the ASG instance count equals manual canary release count
   fail:
-    msg: "Got {{ asg.results[0].instances|length }} instance in asg, and manual `replace_instances` length also same. Canary release should not replace all instances."
+    msg: "Got {{ asg.results[0].instances|length }} instance in asg, and manual `canary_release_instance_ids` length also same. Canary release should not replace all instances."
   when:
-    - replace_instances|length > 0
-    - asg.results[0].instances|length == replace_instances|length
+    - canary_release_instance_ids|length > 0
+    - asg.results[0].instances|length == canary_release_instance_ids|length
 
 
 - name: Create list of instances in current ASG
@@ -115,35 +115,35 @@
     instance_list : "{{ instance_list | default([]) + [ item.instance_id ] }}"
   with_items: "{{ asg.results[0].instances }}"
   when:
-    - canary_release_count > 0 or replace_instances|length > 0
+    - canary_release_count > 0 or canary_release_instance_ids|length > 0
 
 - name: Current instance ids in ASG
   debug:
     msg: "{{ instance_list }}"
     verbosity: 3
   when:
-    - canary_release_count > 0 or replace_instances|length > 0
+    - canary_release_count > 0 or canary_release_instance_ids|length > 0
 
 - name: Check for instances selected manually to be replaced
   fail:
     msg: "Cannot find instance id {{ item }} in asg {{ asg_name }}"
-  with_items: "{{ replace_instances }}"
+  with_items: "{{ canary_release_instance_ids }}"
   when:
-    - replace_instances|length > 0
+    - canary_release_instance_ids|length > 0
     - item not in instance_list
 
 - name: Random Instance Ids that will be replaced in canary release
   set_fact:
-    replace_instances : "{{ instance_list[0:canary_release_count] }}"
+    canary_release_instance_ids : "{{ instance_list[0:canary_release_count] }}"
   when:
     - canary_release_count > 0
 
 - name: Canary release instance ids that will be updated with new AMI
   debug:
-    msg: "{{ replace_instances }}"
+    msg: "{{ canary_release_instance_ids }}"
     verbosity: 3
   when:
-    - replace_instances|length > 0
+    - canary_release_instance_ids|length > 0
 
 
 - name: State the Launch Configuration
@@ -200,12 +200,12 @@
     health_check_type: "{{ asg_health_check_type | default(asg.results[0].health_check_type) }}"
     health_check_period: "{{ asg_health_check_grace_period | default(asg.results[0].health_check_grace_period) }}"
     replace_all_instances: false
-    replace_instances: "{{ replace_instances }}"
+    replace_instances: "{{ canary_release_instance_ids }}"
     wait_for_instances: "{{ asg_wait_for_instances }}"
     wait_timeout: "{{ asg_wait_timeout }}"
     tags: "{{ asg_tags }}"
   when:
-    - replace_instances|length > 0
+    - canary_release_instance_ids|length > 0
 
 - name: Update full ASG
   ec2_asg:
@@ -224,7 +224,7 @@
     wait_timeout: "{{ asg_wait_timeout }}"
     tags: "{{ asg_tags }}"
   when:
-    - replace_instances|length <= 0
+    - canary_release_instance_ids|length <= 0
 
 - name: List of old Launch Configurations to be deleted
   set_fact:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -66,6 +66,34 @@
     msg: "Got {{ old_lc.launch_configurations|length }} lc, expected 1."
   when: old_lc.launch_configurations|length != 1
 
+- name: Fail If the ASG instance count less than canary release count
+  fail:
+    msg: "Got {{ asg.results[0].instances|length }} instance, expected greater than {{ canary_release_count }}. Please check `asg_name` parameter."
+  when:
+    - canary_release_count > 0
+    - asg.results[0].instances|length < canary_release_count
+
+- name: Create list of instances in current ASG
+  set_fact:
+    instance_list : "{{ instance_list | default([]) + [ item.instance_id ] }}"
+  with_items: "{{ asg.results[0].instances }}"
+  when:
+    - canary_release_count > 0
+
+- name: Current instance ids in ASG
+  debug:
+    msg: "{{ instance_list }}"
+    verbosity: 3
+  when:
+    - canary_release_count > 0
+
+- name: Canary release instance ids that will be updated with new AMI
+  debug:
+    msg: "{{ instance_list[0:canary_release_count] }}"
+    verbosity: 3
+  when:
+    - canary_release_count > 0
+
 - name: State the Launch Configuration
   ec2_lc:
     region: "{{ aws_region }}"
@@ -84,7 +112,27 @@
       volume_type: "{{ ebs_volume_type }}"
       delete_on_termination: "{{ ebs_delete_on_termination }}"
 
-- name: Update the ASG
+- name: Canary update the ASG
+  ec2_asg:
+    region: "{{ aws_region }}"
+    default_cooldown: "{{ asg_default_cooldown }}"
+    name: "{{ asg_name }}"
+    launch_config_name: "{{ new_lc_name }}"
+    max_size: "{{ asg_max_size | default(asg.results[0].max_size) }}"
+    min_size: "{{ asg_min_size | default(asg.results[0].min_size) }}"
+    desired_capacity: "{{ asg_desired_capacity | default(asg.results[0].desired_capacity) }}"
+    health_check_type: "{{ asg_health_check_type | default(asg.results[0].health_check_type) }}"
+    health_check_period: "{{ asg_health_check_grace_period | default(asg.results[0].health_check_grace_period) }}"
+    replace_all_instances: false
+    replace_instances: "{{ instance_list[0:canary_release_count] }}"
+    wait_for_instances: "{{ asg_wait_for_instances }}"
+    wait_timeout: "{{ asg_wait_timeout }}"
+    tags: "{{ asg_tags }}"
+  when:
+    - canary_release_count > 0
+
+
+- name: Update full ASG
   ec2_asg:
     region: "{{ aws_region }}"
     default_cooldown: "{{ asg_default_cooldown }}"
@@ -99,6 +147,8 @@
     replace_batch_size: "{{ asg_replace_batch_size | default(omit) }}"
     wait_for_instances: "{{ asg_wait_for_instances }}"
     wait_timeout: "{{ asg_wait_timeout }}"
+  when:
+      - canary_release_count <= 0
 
 - name: Delete the Old Launch Configuration
   ec2_lc:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -66,11 +66,6 @@
     msg: "Got {{ old_lc.launch_configurations|length }} lc, expected 1."
   when: old_lc.launch_configurations|length != 1
 
-- name: Set canary release count variable for backward compatibility
-  set_fact:
-    canary_release_count: 0
-  when: canary_release_count is not defined
-
 - name: Fail If the ASG instance count less than canary release count
   fail:
     msg: "Got {{ asg.results[0].instances|length }} instance, expected greater than {{ canary_release_count }}. Please check `asg_name` parameter."

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,19 @@
     msg: "Detected ansible version is {{ ansible_version.full }}, please use ansible v2.5.x"
   when: ansible_version.full is version('2.5.14', '>') or ansible_version.full is version('2.5.0', '<')
 
+- name: Check if invalid canary release
+  fail:
+    msg: "Got `replace_instances` and `canary_release_count` both set. Please use only 1 parameter at a time for canary release."
+  when:
+    - replace_instances|length > 0
+    - canary_release_count > 0
+
+- name: Set replace_new_instance to true for canary release
+  set_fact:
+    replace_new_instance: true
+  when:
+    - replace_instances|length > 0 or canary_release_count > 0
+
 - name: Get the AMI
   ec2_ami_facts:
     region: "{{ aws_region }}"
@@ -66,33 +79,72 @@
     msg: "Got {{ old_lc.launch_configurations|length }} lc, expected 1."
   when: old_lc.launch_configurations|length != 1
 
-- name: Fail If the ASG instance count less than canary release count
+- name: Fail if replace_new_instances is false but AMI id is new
+  fail:
+      msg: "Got replace_new_instances as false but AMI id doesn't match the current LC Ami id. Please use old AMI id or set replace_new_instances to true"
+  when: old_lc.launch_configurations[0].image_id != ami_id
+
+- name: Find all launch configuration for service
+  ec2_lc_find:
+    region: "{{ aws_region }}"
+    name_regex: "{{service_name }}-{{ cluster_role }}-*"
+  register: all_lc
+
+- name: All found LC for a service
+  debug:
+    msg: "{{ all_lc }}"
+    verbosity: 3
+
+- name: Fail If the ASG instance count less than automatic canary release count
   fail:
     msg: "Got {{ asg.results[0].instances|length }} instance, expected greater than {{ canary_release_count }}. Please check `asg_name` parameter."
   when:
     - canary_release_count > 0
-    - asg.results[0].instances|length < canary_release_count
+    - asg.results[0].instances|length <= canary_release_count
+
+- name: Fail If the ASG instance count equals manual canary release count
+  fail:
+    msg: "Got {{ asg.results[0].instances|length }} instance in asg, and manual `replace_instances` length also same. Canary release should not replace all instances."
+  when:
+    - replace_instances|length > 0
+    - asg.results[0].instances|length == replace_instances|length
+
 
 - name: Create list of instances in current ASG
   set_fact:
     instance_list : "{{ instance_list | default([]) + [ item.instance_id ] }}"
   with_items: "{{ asg.results[0].instances }}"
   when:
-    - canary_release_count > 0
+    - canary_release_count > 0 or replace_instances|length > 0
 
 - name: Current instance ids in ASG
   debug:
     msg: "{{ instance_list }}"
     verbosity: 3
   when:
+    - canary_release_count > 0 or replace_instances|length > 0
+
+- name: Check for instances selected manually to be replaced
+  fail:
+    msg: "Cannot find instance id {{ item }} in asg {{ asg_name }}"
+  with_items: "{{ replace_instances }}"
+  when:
+    - replace_instances|length > 0
+    - item not in instance_list
+
+- name: Random Instance Ids that will be replaced in canary release
+  set_fact:
+    replace_instances : "{{ instance_list[0:canary_release_count] }}"
+  when:
     - canary_release_count > 0
 
 - name: Canary release instance ids that will be updated with new AMI
   debug:
-    msg: "{{ instance_list[0:canary_release_count] }}"
+    msg: "{{ replace_instances }}"
     verbosity: 3
   when:
-    - canary_release_count > 0
+    - replace_instances|length > 0
+
 
 - name: State the Launch Configuration
   ec2_lc:
@@ -124,12 +176,12 @@
     health_check_type: "{{ asg_health_check_type | default(asg.results[0].health_check_type) }}"
     health_check_period: "{{ asg_health_check_grace_period | default(asg.results[0].health_check_grace_period) }}"
     replace_all_instances: false
-    replace_instances: "{{ instance_list[0:canary_release_count] }}"
+    replace_instances: "{{ replace_instances }}"
     wait_for_instances: "{{ asg_wait_for_instances }}"
     wait_timeout: "{{ asg_wait_timeout }}"
     tags: "{{ asg_tags }}"
   when:
-    - canary_release_count > 0
+    - replace_instances|length > 0
 
 - name: Update full ASG
   ec2_asg:
@@ -147,13 +199,29 @@
     wait_for_instances: "{{ asg_wait_for_instances }}"
     wait_timeout: "{{ asg_wait_timeout }}"
   when:
-    - canary_release_count <= 0
+    - replace_instances|length <= 0
 
-- name: Delete the Old Launch Configuration
+- name: List of old Launch Configurations to be deleted
+  set_fact:
+    old_lc_to_delete : "{{ old_lc_to_delete | default([]) + [ item.name ] }}"
+  with_items: "{{ all_lc.results }}"
+  when:
+    - item.name != new_lc_name
+    - item.name is search("-" + launch_configuration_name_suffix + "$")
+
+- name: List of to be deleted old Launch Configurations
+  debug:
+    msg: "{{ old_lc_to_delete }}"
+    verbosity: 3
+  when:
+    - old_lc_to_delete|length > 0
+
+- name: Delete all the Old Launch Configuration
   ec2_lc:
     region: "{{ aws_region }}"
-    name: "{{ old_lc_name }}"
+    name: "{{ item }}"
     state: absent
+  with_items: "{{ old_lc_to_delete }}"
   when:
-    - old_lc_name != new_lc_name
-    - old_lc_name is search("-" + launch_configuration_name_suffix + "$")
+   - old_lc_to_delete|length > 0
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -66,6 +66,11 @@
     msg: "Got {{ old_lc.launch_configurations|length }} lc, expected 1."
   when: old_lc.launch_configurations|length != 1
 
+- name: Set canary release count variable for backward compatibility
+  set_fact:
+    canary_release_count: 0
+  when: canary_release_count is not defined
+
 - name: Fail If the ASG instance count less than canary release count
   fail:
     msg: "Got {{ asg.results[0].instances|length }} instance, expected greater than {{ canary_release_count }}. Please check `asg_name` parameter."
@@ -130,7 +135,6 @@
     tags: "{{ asg_tags }}"
   when:
     - canary_release_count > 0
-
 
 - name: Update full ASG
   ec2_asg:


### PR DESCRIPTION
<!--
    Please insert texts after the comment blocks & preview them before submitting PRs
-->

## Summary
<!-- A brief description about the changes proposed in the pull request. e.g.:

add pull requests template to standardize pull request content to make code review process more comfortable for both the change creators and reviewers

-->
Added `canary_release_count` variable and `canary_release_instance_ids` variable and logic to allow canary release in new ASG deployment. Now automatic release, by giving number of instance to do canary release or manual release, by giving instance ids to release new AMI can be done.
## Test Plan
<!-- (from https://secure.phabricator.com/book/phabricator/article/differential_test_plans/ You can find more useful information about test plan there)

A test plan is a repeatable list of steps which document what you have done to verify the behavior of a change. A good test plan convinces a reviewer that you have been thorough in making sure your change works as intended and has enough detail to allow someone unfamiliar with your change to verify its behavior. -->
Tested the logic for selecting instances in canary release. Pending testing on actual/mock ASG.
[1] Tested setting both `canary_release_count` and `canary_release_instance_ids` and get failed deployment as expected.
[2] Set only `canary_release_count` to 2 and `canary_release_instance_ids` as empty array and get successful list of random 2 instance ids.
[3] Set only `canary_release_instance_ids` to valid 2 instance id and `canary_release_count` as 0 and get successful list of 2 selected instance ids. 
[4] Set only `canary_release_instance_ids` to 1 valid and 1 invalid instance id and `canary_release_count` as 0 and get failed deployment as expected.
[5] Test setting `canary_release_count` as 0 and `canary_release_instance_ids` as empty list and get full deployment as expected.
[6] Test setting `canary_release_count` as 10 greater than or equal ASG size and `canary_release_instance_ids` as empty list and get failed deployment as expected.
[7] Test setting `canary_release_instance_ids` as list of all ASG instance and `canary_release_count` as 0 and get failed deployment as expected.


## Subscribers
<!-- mentions who should be notified about your changes, e.g.:

- @username
- @organization/team-name

These people will get GitHub notifications after this PR is created
-->
@salvianreynaldi 
@rifandi-tvlk 
@apermana22 