### PR TITLE
[Fix] Canary deployment

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -114,7 +114,7 @@
 
 - name: Create list of instances in current ASG
   set_fact:
-    instance_list : "{{ instance_list | default([]) + [ item.instance_id ] }}"
+    instance_list: "{{ instance_list | default([]) + [ item.instance_id ] }}"
   with_items: "{{ asg.results[0].instances }}"
   when:
     - canary_release_count > 0 or canary_release_instance_ids|length > 0
@@ -136,7 +136,7 @@
 
 - name: Random Instance Ids that will be replaced in canary release
   set_fact:
-    canary_release_instance_ids : "{{ instance_list[0:canary_release_count] }}"
+    canary_release_instance_ids: "{{ instance_list[0:canary_release_count] }}"
   when:
     - canary_release_count > 0
 
@@ -161,10 +161,10 @@
     instance_monitoring: "{{ old_lc.launch_configurations[0].instance_monitoring.enabled }}"
     ebs_optimized: "{{ old_lc.launch_configurations[0].ebs_optimized }}"
     volumes:
-    - device_name: "{{ ebs_device_name }}"
-      volume_size: "{{ ebs_volume_size }}"
-      volume_type: "{{ ebs_volume_type }}"
-      delete_on_termination: "{{ ebs_delete_on_termination }}"
+      - device_name: "{{ ebs_device_name }}"
+        volume_size: "{{ ebs_volume_size }}"
+        volume_type: "{{ ebs_volume_type }}"
+        delete_on_termination: "{{ ebs_delete_on_termination }}"
 
 - name: Set ASG tags list to empty array.
   set_fact:
@@ -229,7 +229,7 @@
 
 - name: List of old Launch Configurations to be deleted
   set_fact:
-    old_lc_to_delete : "{{ old_lc_to_delete | default([]) + [ item.name ] }}"
+    old_lc_to_delete: "{{ old_lc_to_delete | default([]) + [ item.name ] }}"
   with_items: "{{ all_lc.results }}"
   when:
     - item.name != new_lc_name
@@ -249,5 +249,5 @@
     state: absent
   with_items: "{{ old_lc_to_delete }}"
   when:
-   - old_lc_to_delete|length > 0
+    - old_lc_to_delete|length > 0
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -81,8 +81,10 @@
 
 - name: Fail if replace_new_instances is false but AMI id is new
   fail:
-      msg: "Got replace_new_instances as false but AMI id doesn't match the current LC Ami id. Please use old AMI id or set replace_new_instances to true"
-  when: old_lc.launch_configurations[0].image_id != ami_id
+    msg: "Got replace_new_instances as false but AMI id doesn't match the current LC Ami id. Please use old AMI id or set replace_new_instances to true"
+  when:
+    - replace_new_instances != true
+    - old_lc.launch_configurations[0].image_id != ami_id
 
 - name: Find all launch configuration for service
   ec2_lc_find:
@@ -188,7 +190,7 @@
     msg: "{{ asg_tags }}"
     verbosity: 3
 
--- name: Canary update the ASG
+- name: Canary update the ASG
   ec2_asg:
     region: "{{ aws_region }}"
     default_cooldown: "{{ asg_default_cooldown }}"
@@ -199,7 +201,6 @@
     desired_capacity: "{{ asg_desired_capacity | default(asg.results[0].desired_capacity) }}"
     health_check_type: "{{ asg_health_check_type | default(asg.results[0].health_check_type) }}"
     health_check_period: "{{ asg_health_check_grace_period | default(asg.results[0].health_check_grace_period) }}"
-    replace_all_instances: false
     replace_instances: "{{ canary_release_instance_ids }}"
     wait_for_instances: "{{ asg_wait_for_instances }}"
     wait_timeout: "{{ asg_wait_timeout }}"


### PR DESCRIPTION
## Summary
- previously using double dash "--" on Canary release stage, which cause error
- another layer of checking needed on stage `Fail if replace_new_instances is false but AMI id is new`
- `replace_all_instances` and `replace_instances` are mutually exclusive, and since seems there is no point on putting `replace_all_instances` we remove that.

p.s. please check on Fix canary configuration commit for clear changes, since I also include indentation fix in this change

## Test Plan
staging

## Subscribers
@salvianreynaldi 
@arpit9508 
