### PR TITLE
[Fix] Remove unnecessary dash on canary

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -188,7 +188,7 @@
     msg: "{{ asg_tags }}"
     verbosity: 3
 
--- name: Canary update the ASG
+- name: Canary update the ASG
   ec2_asg:
     region: "{{ aws_region }}"
     default_cooldown: "{{ asg_default_cooldown }}"


### PR DESCRIPTION
## Summary
There were error on applying blue green deployment using latest release, caused by unnecessary dash on canary update stage.

## Test Plan
staging

## Subscribers
@salvianreynaldi 
