### PR TITLE
add `nonprodmonitoring` for staging deployment datadog metrics

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,3 +10,4 @@ launch_configuration_name_suffix: rolling
 replace_new_instances: true
 canary_release_count: 0
 canary_release_instance_ids: []
+non_prod_monitoring: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -182,6 +182,7 @@
   with_items:
     - { key: "AmiId", value: "{{ ami_id }}" }
     - { key: "ManagedBy", value: "ansible" }
+    - { key: "nonprodmonitoring", value: "{{ non_prod_monitoring }}" }
 
 - name: The Final tags to be updated to ASG
   debug:


### PR DESCRIPTION
## Summary
Since backend Infra team are limiting monitored hosts on DataDog Traveloka Dev account, there will still be a requirement for developer to perform load test, thus need to have proper metrics set up and populated by adding the tag `nonprodmonitoring:true` on the ASG tags. 

## Test Plan
staging

## Subscribers
@salvianreynaldi 
